### PR TITLE
Fix installation of Symfony CLI

### DIFF
--- a/provisioning/roles/symfony/tasks/main.yml
+++ b/provisioning/roles/symfony/tasks/main.yml
@@ -1,8 +1,7 @@
 ---
-- name: setup framework installer
-  shell: creates=/usr/local/bin/symfony
-    curl -LsS http://symfony.com/installer -o /usr/local/bin/symfony
+- name: install symfony repository
+  shell: |
+    curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.deb.sh' | sudo -E bash
 
-- name: make framework installer executable
-  file: path=/usr/local/bin/symfony mode='a+x'
-
+- name: install symfony-cli
+  apt: name="symfony-cli"


### PR DESCRIPTION
Currently, `/usr/local/bin/symfony` is invalid (it contains HTML).

Installation process has been changed (see the [documentation](https://symfony.com/download) for more information).