### PR TITLE
nvim-dap-ui now requires nvim-nio

### DIFF
--- a/provisioning/roles/neovim/files/init.vim
+++ b/provisioning/roles/neovim/files/init.vim
@@ -37,6 +37,8 @@ endif
 " - Avoid using standard Vim directory names like 'plugin'
 call plug#begin('~/.local/share/nvim/plugged')
 
+Plug 'nvim-neotest/nvim-nio'
+
 Plug 'folke/tokyonight.nvim', { 'branch': 'main' }
 
 Plug 'ntpeters/vim-better-whitespace'


### PR DESCRIPTION
(starting from tag 4.0.0, this is marked as a breaking change)

The error when starting nvim with the configuration: E5108: Error executing lua ....local/share/nvim/plugged/nvim-dap-ui/lua/dapui/init.lua:36: nvim-dap-ui requires nvim-nio to be installed. Install from https://github.com/nvim-neotest/nvim-nio

The breaking change changelog:
https://github.com/rcarriga/nvim-dap-ui/releases/tag/v4.0.0

Running PlugInstall afterwards fixes the issue.